### PR TITLE
Refresh window titles on startup and window restore

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,5 +1,6 @@
+import {getDataStore} from './datastore.js';
+
 browser.windows.onCreated.addListener(async (window) => {
-    const mod = await import('./datastore.js');
-    const store = mod.getDataStore();
+    const store = getDataStore();
     await store.refreshAppearanceForWindow(window.id);
 });

--- a/background.js
+++ b/background.js
@@ -4,3 +4,10 @@ browser.windows.onCreated.addListener(async (window) => {
     const store = getDataStore();
     await store.refreshAppearanceForWindow(window.id);
 });
+
+// Session values for restored windows may not be available when onCreated
+// fires; refresh again when a tab becomes active in the window.
+browser.tabs.onActivated.addListener(async ({windowId}) => {
+    const store = getDataStore();
+    await store.refreshAppearanceForWindow(windowId);
+});

--- a/background.js
+++ b/background.js
@@ -1,13 +1,5 @@
-const dataStore = import("./datastore.js").then((dataStore) => {
-    console.debug("background importing dataStore");
-
-    let store = dataStore.getDataStore();
-    if (!store) {
-        store = new dataStore.DataStore();
-        dataStore.setDataStore(store);
-    }
+browser.windows.onCreated.addListener(async (window) => {
+    const mod = await import('./datastore.js');
+    const store = mod.getDataStore();
+    await store.refreshAppearanceForWindow(window.id);
 });
-
-console.debug("background module-level");
-
-console.debug('Background script loaded');

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "Kitsune",
   "version": "0.2",
   "description": "Manages tabs and windows",
@@ -17,11 +17,11 @@
   ],
 
   "background": {
-    "scripts": ["background.js"],
-    "persistent": false
+    "service_worker": "background.js",
+    "type": "module"
   },
 
-  "browser_action": {
+  "action": {
     "default_icon": "icons/kitsune_thick.svg",
     "default_title": "Kitsune",
     "default_popup": "popup/popup.html"

--- a/manifest.json
+++ b/manifest.json
@@ -17,7 +17,7 @@
   ],
 
   "background": {
-    "service_worker": "background.js",
+    "scripts": ["background.js"],
     "type": "module"
   },
 


### PR DESCRIPTION
## Summary
- Upgrade to manifest v3; use background.scripts with type:module (service_worker is still behind a flag in Firefox)
- Refresh titlePreface on windows.onCreated so new windows get their title applied immediately
- Also refresh on tabs.onActivated to handle restored windows, where session values are not yet available when onCreated fires

## Test plan
- [ ] Load extension and verify existing windows show correct title brackets
- [ ] Close a titled window and reopen it from History > Recently Closed Windows; verify title bracket reappears
- [ ] Open a new window; verify it gets no brackets (no stored title)
- [ ] Switch tabs; verify title is stable and does not flicker

Generated with Claude Code