### PR TITLE
Fix build/sign ignore lists and add AMO link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # kitsune
 Firefox extension for managing tabs and windows
 
+https://addons.mozilla.org/en-US/firefox/addon/kitsune2/
+
 Inspired by https://github.com/tpamula/webextension-window-titler

--- a/build.sh
+++ b/build.sh
@@ -2,4 +2,5 @@ VERSION="$(cat manifest.json | jq -r .version)"
 web-ext build -n kitsune-$VERSION.zip -o \
   -i CLAUDE.md kitsune-windows*.json *.sh *.py instance notes.md \
   -i tools logo package.json package-lock.json \
-  -i icons/bolt.png icons/read_more.png icons/sunny.png icons/kitsune.svg
+  -i icons/bolt.png icons/sunny.png icons/kitsune.svg \
+  -i LICENSE README.md .gitignore

--- a/sign.sh
+++ b/sign.sh
@@ -2,7 +2,8 @@ VERSION="$(cat manifest.json | jq -r .version)"
 web-ext sign \
   -i CLAUDE.md kitsune-windows*.json *.sh *.py instance notes.md \
   -i tools logo package.json package-lock.json \
-  -i icons/bolt.png icons/read_more.png icons/sunny.png icons/kitsune.svg \
+  -i icons/bolt.png icons/sunny.png icons/kitsune.svg \
+  -i LICENSE README.md .gitignore \
   --api-key "$AMO_JWT_ISSUER" \
   --api-secret "$AMO_JWT_SECRET" \
   --channel unlisted


### PR DESCRIPTION
## Summary
- Remove `icons/read_more.png` from build/sign exclusions — it is used by switch-to-window/tab buttons
- Add `LICENSE`, `README.md`, `.gitignore` to exclusions
- Add AMO listing link to README

## Test plan
- [ ] Run `build.sh` and verify `read_more.png` is included in the zip
- [ ] Verify `LICENSE`, `README.md`, `.gitignore` are not included in the zip