### PR TITLE
Fix release version number

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,16 @@
-VERSION="$(cat manifest.json | jq -r .version)"
+TAG=$(git describe --exact-match --tags 2>/dev/null | sed 's/^v//')
+if [[ -z "$TAG" ]]; then
+  echo "Error: current commit is not tagged" >&2
+  exit 1
+fi
+
+MANIFEST_VERSION="$(cat manifest.json | jq -r .version)"
+if [[ "$TAG" != "$MANIFEST_VERSION" ]]; then
+  echo "Error: git tag ($TAG) does not match manifest version ($MANIFEST_VERSION)" >&2
+  exit 1
+fi
+
+VERSION="$TAG"
 web-ext build -n kitsune-$VERSION.zip -o \
   -i CLAUDE.md kitsune-windows*.json *.sh *.py instance notes.md \
   -i tools package.json package-lock.json \

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Kitsune",
-  "version": "0.3",
+  "version": "0.4",
   "description": "Manages tabs and windows",
   "homepage_url": "https://github.com/izrik/kitsune",
   "icons": {


### PR DESCRIPTION
## Summary
- Bump manifest version to 0.4 (was forgotten before the v0.4 release)
- Add version/tag consistency check to build.sh: fails if the current commit is not tagged or if the tag does not match the manifest version

## Test plan
- [ ] build.sh fails on an untagged commit
- [ ] build.sh fails if tag and manifest version do not match
- [ ] build.sh succeeds on a commit tagged v0.4

Generated with Claude Code